### PR TITLE
Unit tests & function moved

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,7 +21,6 @@ parameters:
 		- tests/phpstan/bootstrap.php
 	scanDirectories:
 	    - tests/plugins/TesterPlugin
-	    - plugins
 	scanFiles:
 		- src/pocketmine/PocketMine.php
 		- build/make-release.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,7 @@ parameters:
 		- tests/phpstan/bootstrap.php
 	scanDirectories:
 	    - tests/plugins/TesterPlugin
+	    - plugins
 	scanFiles:
 		- src/pocketmine/PocketMine.php
 		- build/make-release.php

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -271,7 +271,7 @@ class PluginManager{
 
 					$pluginPhpVersions = $description->getCompatiblePhpVersions();
 					$pluginCompatiblePhpVersions = array_filter($pluginPhpVersions, function(string $requiredVersion) : bool{
-						return version_compare(PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION, $requiredVersion, "<=") and version_compare(PHP_VERSION, $requiredVersion, ">=") and version_compare(PHP_MAJOR_VERSION . "." . (PHP_MINOR_VERSION + 1), $requiredVersion, ">");
+						return self::isCompatiblePhp($requiredVersion);
 					});
 					if(count($pluginPhpVersions) > 0 and count($pluginCompatiblePhpVersions) < 1){
 						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
@@ -373,6 +373,16 @@ class PluginManager{
 		}
 
 		return $loadedPlugins;
+	}
+
+	/**
+	 * Returns whether the plugin PHP version specified is compatible with the server's PHP version.
+	 */
+	public static function isCompatiblePhp(string $pluginVersion, string $serverVersion = PHP_VERSION) : bool{
+		$serverParts = explode(".", $serverVersion);
+		return version_compare($serverParts[0] . "." . $serverParts[1], $pluginVersion, "<=") and
+			version_compare($serverVersion, $pluginVersion, ">=") and
+			version_compare($serverParts[0] . "." . ((int)$serverParts[1] + 1), $pluginVersion, ">");
 	}
 
 	/**

--- a/tests/phpunit/plugin/CompatiblePhpTest.php
+++ b/tests/phpunit/plugin/CompatiblePhpTest.php
@@ -33,6 +33,9 @@ class CompatiblePhpTest extends TestCase{
 	 */
 	public function incompatiblePhpVersions() : array{
 		return [
+			["5.0", "5.1.0"],
+			["5.2", "5.1.0"],
+			["5", "5.0.0"],
 			["5.0.0", "7.0.0"],
 			["7.0.0", "5.0.0"],
 			["7.2.0", "7.1.0"],
@@ -48,6 +51,9 @@ class CompatiblePhpTest extends TestCase{
 	 */
 	public function compatiblePhpVersions() : array{
 		return [
+			["5.0", "5.0.0"],
+			["5.0", "5.0.2"],
+			["5.2", "5.2.2"],
 			["5.0.0", "5.0.0"],
 			["7.3.0", "7.3.0"],
 			["7.1.2", "7.1.5"],

--- a/tests/phpunit/plugin/CompatiblePhpTest.php
+++ b/tests/phpunit/plugin/CompatiblePhpTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\plugin;
+
+use PHPUnit\Framework\TestCase;
+
+class CompatiblePhpTest extends TestCase{
+
+	/**
+	 * @return string[][]
+	 * @phpstan-return list<array{string}>
+	 */
+	public function incompatiblePhpVersions() : array{
+		return [
+			["5.0.0", "7.0.0"],
+			["7.0.0", "5.0.0"],
+			["7.2.0", "7.1.0"],
+			["7.2.0", "7.3.0"],
+			["7.1.4", "7.1.3"],
+			["7.0.0", "5.0.0"]
+		];
+	}
+
+	/**
+	 * @return string[][]
+	 * @phpstan-return list<array{string}>
+	 */
+	public function compatiblePhpVersions() : array{
+		return [
+			["5.0.0", "5.0.0"],
+			["7.3.0", "7.3.0"],
+			["7.1.2", "7.1.5"],
+			["8.0.0", "8.0.2"]
+		];
+	}
+
+	/**
+	 * @dataProvider incompatiblePhpVersions
+	 */
+	public function testIncompatibleVersions(string $pluginVersion, string $serverVersion) : void{
+		self::assertFalse(PluginManager::isCompatiblePhp($pluginVersion, $serverVersion));
+	}
+
+	/**
+	 * @dataProvider compatiblePhpVersions
+	 */
+	public function testCompatibleVersions(string $pluginVersion, string $serverVersion) : void{
+		self::assertTrue(PluginManager::isCompatiblePhp($pluginVersion, $serverVersion));
+	}
+}


### PR DESCRIPTION
## Changes
### API changes
`PluginManager::isCompatiblePhp(string $pluginVersion, string $serverVersion) : bool;`

## Tests
Unit test added for the above demonstrating both compatible and incompatible versions.

See https://travis-ci.com/github/JaxkDev/PocketMine-MP/jobs/468291167#L653

## Plugin Tests
Run with a server PHP version of 7.4.13.

When plugin specified `php: [7.1,7.2,7.3]`
![image](https://user-images.githubusercontent.com/25908768/103574398-be1d9400-4ec7-11eb-9321-eb1f238ea281.png)

When plugin specified `php: [7.1,7.2,7.3,7.4]`
Plugin Loads.

When plugin specified `php: 7.4` or `php: [7.4]`
Plugin Loads.

When plugin specified `php: 7.4.0` or `php: 7.4.12`
Plugin Loads.

When plugin specified `php: 7.5`:
![image](https://user-images.githubusercontent.com/25908768/103574690-48fe8e80-4ec8-11eb-9744-70c3aad86270.png)

When plugin specified `php: 8.0`:
Plugin will not load, 
![image](https://user-images.githubusercontent.com/25908768/103575219-4a7c8680-4ec9-11eb-8bd4-a539e88b232e.png)

To conclude all php versions should be strings eg:
```
php: "8.0"
php: ["8.0", "8.1"]
```

